### PR TITLE
fix(cmake_build): correct submodule paths for tam__common dependencies

### DIFF
--- a/cmake_build/CMakeLists.txt
+++ b/cmake_build/CMakeLists.txt
@@ -27,11 +27,11 @@ endforeach()
 
 # Manually add the extra dependencies with absolute paths
 set(EXTRA_DEPS
-    "dependencies/iac_common/submodules/parameter_management/param_management_cpp"
-    "dependencies/iac_common/submodules/time_series_logging/tsl_logger_cpp"
-    "dependencies/iac_common/tum_helpers_cpp"
-    "dependencies/iac_common/tum_types_cpp"
-    "dependencies/iac_common/vendor_pkgs/matplotlib_cpp"
+    "submodules/tam__common/submodules/parameter_management/param_management_cpp"
+    "submodules/tam__common/submodules/time_series_logging/tsl_logger_cpp"
+    "submodules/tam__common/tum_helpers_cpp"
+    "submodules/tam__common/tum_types_cpp"
+    "submodules/tam__common/vendor_pkgs/matplotlib_cpp"
 )
 
 foreach(DEP ${EXTRA_DEPS})


### PR DESCRIPTION
## Summary

- The `EXTRA_DEPS` list in `cmake_build/CMakeLists.txt` pointed at `dependencies/iac_common/...`, a path that does not exist in the current repository layout.
- Per `.gitmodules`, the only submodule is `submodules/tam__common`, which contains all of the expected sub-packages (`tum_types_cpp`, `tum_helpers_cpp`, `vendor_pkgs/matplotlib_cpp`, plus nested `parameter_management` and `time_series_logging` submodules).
- After `git submodule update --init --recursive`, the non-colcon `cmake_build` flow still fails because the include directories are never added. Concretely:

  ```
  fatal error: tum_types_cpp/common.hpp: No such file or directory
      7 | #include <tum_types_cpp/common.hpp>
  ```

- This patch updates the five `EXTRA_DEPS` entries to use the correct `submodules/tam__common/...` prefix so the standalone CMake build (documented in `cmake_build/Readme.md`) works out of the box.